### PR TITLE
Add settings to control text shadow and see-through.

### DIFF
--- a/src/main/java/com/provismet/provihealth/compat/ProviHealthConfigScreen.java
+++ b/src/main/java/com/provismet/provihealth/compat/ProviHealthConfigScreen.java
@@ -29,6 +29,7 @@ public class ProviHealthConfigScreen {
         ConfigCategory hud = builder.getOrCreateCategory(Text.translatable("category.provihealth.hud"));
         ConfigCategory health = builder.getOrCreateCategory(Text.translatable("category.provihealth.health"));
         ConfigCategory particles = builder.getOrCreateCategory(Text.translatable("category.provihealth.particles"));
+        ConfigCategory compatibility = builder.getOrCreateCategory(Text.translatable("category.provihealth.compat"));
 
         hud.addEntry(entryBuilder.startIntField(Text.translatable("entry.provihealth.hudDuration"), Options.maxHealthBarTicks)
             .setDefaultValue(40)
@@ -147,6 +148,12 @@ public class ProviHealthConfigScreen {
         health.addEntry(entryBuilder.startBooleanToggle(Text.translatable("entry.provihealth.worldText"), Options.showTextInWorld)
             .setDefaultValue(true)
             .setSaveConsumer(newValue -> Options.showTextInWorld = newValue)
+            .build()
+        );
+
+        health.addEntry(entryBuilder.startBooleanToggle(Text.translatable("entry.provihealth.worldShadows"), Options.worldShadows)
+            .setDefaultValue(true)
+            .setSaveConsumer(newValue -> Options.worldShadows = newValue)
             .build()
         );
 
@@ -312,6 +319,13 @@ public class ProviHealthConfigScreen {
             .setDefaultValue(16f)
             .setMin(0f)
             .setSaveConsumer(newValue -> Options.maxParticleDistance = newValue)
+            .build()
+        );
+
+        compatibility.addEntry(entryBuilder.startBooleanToggle(Text.translatable("entry.provihealth.compatText"), Options.noSeeThroughText)
+            .setDefaultValue(false)
+            .setTooltip(Text.translatable("tooltip.provihealth.compatText"))
+            .setSaveConsumer(newValue -> Options.noSeeThroughText = newValue)
             .build()
         );
 

--- a/src/main/java/com/provismet/provihealth/config/Options.java
+++ b/src/main/java/com/provismet/provihealth/config/Options.java
@@ -68,6 +68,7 @@ public class Options {
     public static Vector3f unpackedEndWorld = Vec3d.unpackRgb(worldEndColour).toVector3f();
     public static boolean worldGradient = false;
     public static boolean overrideLabels = false;
+    public static boolean worldShadows = true;
 
     public static boolean spawnDamageParticles = true;
     public static boolean spawnHealingParticles = false;
@@ -80,6 +81,8 @@ public class Options {
     public static int particleTextColour = 0xFFFFFF;
     public static DamageParticleType particleType = DamageParticleType.RISING;
     public static float maxParticleDistance = 16f;
+
+    public static boolean noSeeThroughText = false;
 
     @SuppressWarnings("resource")
     public static boolean shouldRenderHealthFor (LivingEntity livingEntity) {
@@ -139,6 +142,7 @@ public class Options {
             .append("replaceLabels", overrideLabels).newLine()
             .append("worldGlide", worldGlide).newLine()
             .append("worldHealthText", showTextInWorld).newLine()
+            .append("worldTextShadows", worldShadows).newLine()
             .append("maxRenderDistance", maxRenderDistance).newLine()
             .append("barScale", worldHealthBarScale).newLine()
             .append("worldGradient", worldGradient).newLine()
@@ -165,6 +169,7 @@ public class Options {
             .append("particleTextColour", particleTextColour).newLine()
             .append("particleType", particleType.name()).newLine()
             .append("maxParticleDistance", maxParticleDistance).newLine()
+            .append("topLayerText", noSeeThroughText).newLine()
             .createArray("healthBlacklist", blacklist).newLine()
             .createArray("hudBlacklist", blacklistHUD).newLine(false)
             .closeObject()
@@ -238,6 +243,10 @@ public class Options {
 
                     case "worldHealthText":
                         showTextInWorld = parser.nextBoolean();
+                        break;
+
+                    case "worldTextShadows":
+                        worldShadows = parser.nextBoolean();
                         break;
                     
                     case "maxRenderDistance":
@@ -346,6 +355,10 @@ public class Options {
 
                     case "maxParticleDistance":
                         maxParticleDistance = (float)parser.nextDouble();
+                        break;
+
+                    case "topLayerText":
+                        noSeeThroughText = parser.nextBoolean();
                         break;
 
                     case "healthBlacklist":

--- a/src/main/java/com/provismet/provihealth/world/EntityHealthBar.java
+++ b/src/main/java/com/provismet/provihealth/world/EntityHealthBar.java
@@ -116,9 +116,11 @@ public class EntityHealthBar {
                     nameY -= 9;
                 }
 
-                if (target.shouldRenderName() && !target.isSneaky()) {
-                    textRenderer.draw(targetName, nameX + 1, nameY + 1, 0x404040, false, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
-                    textRenderer.draw(healthString, healthX + 1, healthY + 1, 0x404040, false, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
+                if (target.shouldRenderName() && !target.isSneaky() && !Options.noSeeThroughText) {
+                    if (Options.worldShadows) {
+                        textRenderer.draw(targetName, nameX + 1, nameY + 1, 0x404040, false, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
+                        textRenderer.draw(healthString, healthX + 1, healthY + 1, 0x404040, false, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
+                    }
 
                     matrices.translate(0, 0, 0.03f);
                     textModel = matrices.peek().getPositionMatrix();
@@ -126,11 +128,11 @@ public class EntityHealthBar {
                     textRenderer.draw(healthString, healthX, healthY, 0xFFFFFF, false, textModel, vertexConsumers, TextLayerType.SEE_THROUGH, 0, light);
                 }
                 else {
-                    textRenderer.draw(targetName, nameX, nameY, 0xFFFFFF, true, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
-                    textRenderer.draw(healthString, healthX, healthY, 0xFFFFFF, true, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
+                    textRenderer.draw(targetName, nameX, nameY, 0xFFFFFF, Options.worldShadows, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
+                    textRenderer.draw(healthString, healthX, healthY, 0xFFFFFF, Options.worldShadows, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
                 }
             }
-            else textRenderer.draw(healthString, -(textRenderer.getWidth(healthString)) / 2f, -10, 0xFFFFFF, true, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
+            else textRenderer.draw(healthString, -(textRenderer.getWidth(healthString)) / 2f, -10, 0xFFFFFF, Options.worldShadows, textModel, vertexConsumers, TextLayerType.NORMAL, 0, light);
             matrices.pop();
         }
 

--- a/src/main/resources/assets/provihealth/lang/en_us.json
+++ b/src/main/resources/assets/provihealth/lang/en_us.json
@@ -5,6 +5,7 @@
     "category.provihealth.hud": "HUD",
     "category.provihealth.health": "In-World",
     "category.provihealth.particles": "Particles",
+    "category.provihealth.compat": "Compatibility",
 
     "subcategory.provihealth.boss": "Bosses",
     "subcategory.provihealth.hostile": "Hostile Mobs",
@@ -40,6 +41,8 @@
     "entry.provihealth.barStartColour": "Full Health Colour",
     "entry.provihealth.barEndColour": "Low Health Colour",
     "entry.provihealth.overrideLabels": "Replace Nameplates",
+    "entry.provihealth.worldShadows": "Text Shadow",
+    "entry.provihealth.compatText": "Disable Top-Layer Text",
 
     "enum.provihealth.full": "Full",
     "enum.provihealth.portrait_only": "Portrait Only",
@@ -64,6 +67,7 @@
     "tooltip.provihealth.hudOffsetY": "As a percentage of the window height.",
     "tooltip.provihealth.gradient": "Whether or not the health bar will change color as it gets lower.\nTurning this off sets the bar color to the starting value.",
     "tooltip.provihealth.overrideLabels": "When true health bar text will include the name of the mob and nameplates will not be rendered.\nWhen false health bar text will only show the health values, and the bar will move upwards when a nameplate is being rendered.\nWarning: Only the name of the mob is added to the health bar, if a mod/plugin/scoreboard adds additional lines of text to the nameplate then that text will be lost.",
+    "tooltip.provihealth.compatText": "Prevents in-world health bar text from rendering through walls for mobs that have top-layer nameplates (such as Players).\nThis is a compatibility setting and should only be used if another mod is causing text for those mobs to render incorrectly.",
 
     "entity.provihealth.unknownPlayer": "[Invisible Player]"
 }


### PR DESCRIPTION
Modpack testing revealed that SEE_THROUGH text (Players) breaks text shadows. This PR adds config options to either disable SEE_THROUGH text or shadows.