### PR TITLE
Update issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,17 +27,11 @@ body:
       placeholder: Affected mod version or versions. Do NOT simply write "latest".
     validations:
       required: true
-  - type: dropdown
+  - type: input
     id: mc-ver
     attributes:
       label: Minecraft Version
-      multiple: true
-      options:
-        - 1.20.4
-        - 1.20.3
-        - 1.20.2
-        - 1.20.1
-        - 1.20
+      placeholder: Affected Minecraft version or versions. Do NOT simply write "latest".
     validations:
       required: true
   - type: dropdown
@@ -56,7 +50,6 @@ body:
     attributes:
       label: Steps to Reproduce
       placeholder: Write steps out here, e.g. in bullet points...
-      render: bash
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/incompat.yml
+++ b/.github/ISSUE_TEMPLATE/incompat.yml
@@ -34,17 +34,11 @@ body:
       placeholder: Affected mod version or versions. Do NOT simply write "latest".
     validations:
       required: true
-  - type: dropdown
+  - type: input
     id: mc-ver
     attributes:
       label: Minecraft Version
-      multiple: true
-      options:
-        - 1.20.4
-        - 1.20.3
-        - 1.20.2
-        - 1.20.1
-        - 1.20
+      placeholder: Affected Minecraft version or versions. Do NOT simply write "latest".
     validations:
       required: true
   - type: dropdown
@@ -63,7 +57,6 @@ body:
     attributes:
       label: Steps to Reproduce
       placeholder: Write steps out here, e.g. in bullet points...
-      render: bash
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
1.20.6 is expected to be the last Minecraft 1.20 version. The 1.20.6 branch will be the new master branch, so I need to make sure the issue templates are right.